### PR TITLE
Add 36to48 to submissions.yml

### DIFF
--- a/submissions.yml
+++ b/submissions.yml
@@ -25,3 +25,4 @@ projects:
   - "https://github.com/Dragon863/CFWatch/"
   - "https://github.com/hunkegg/biblicallyaccuratekeyboard"
   - "https://github.com/Programer6/Laser-Engraving-Machine"
+  - "https://github.com/matebuteler/36to48"


### PR DESCRIPTION
A module that turns your 36V e-vehicle into 48V. BMS, battery casing and other doodads included.