### PR TITLE
Automatically load submission data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,11 @@
 
 .DS_Store
 # Ignore Mac system files
+
+# Ignore all projects
+/content/projects/*
+
+# But do NOT ignore the dev example project
+!/content/projects/hackclub/
+!/content/projects/hackclub/awesome-project/
+!/content/projects/hackclub/awesome-project/**

--- a/README.md
+++ b/README.md
@@ -33,3 +33,11 @@ Done your project + want to submit it to get your grant? Submit it in the form h
 Remember to read through the [submission guidelines](https://highway.hackclub.com/advanced/submitting) before submitting! 
 
 # Ready. Set. Build!
+
+---
+
+# Website development
+
+Ooooh, you're in the README to figure out how the actual highway website works? Sure!
+
+It's a standard rails codebase, but when you first start up you might want to run `bin/rails projects:clone` to download all the submissions.

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,14 +1,13 @@
 class ProjectsController < ApplicationController
-  include MarkdownRenderable
-  require "yaml"
-
   def index
     @projects = Project.all
+
+    CloneProjectsJob.perform_later if @projects.empty?
   end
 
   def show
-    @project = Project.find(params[:repo], params[:project_name])
-    render_not_found unless @project
+    @project = Project.find(params[:user], params[:project_name])
+    not_found unless @project
   end
 
   def new

--- a/app/jobs/clone_projects_job.rb
+++ b/app/jobs/clone_projects_job.rb
@@ -1,0 +1,26 @@
+class CloneProjectsJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    submissions = YAML.load_file(Rails.root.join("submissions.yml"))
+
+    submissions["projects"].each do |url|
+      url = url.chomp("/")
+      url = "#{url}.git" unless url.end_with?(".git")
+
+      org, repo = url.gsub("https://github.com/", "").gsub(".git", "").split("/")
+
+      target_dir = File.join(Rails.root, "content", "projects", org, repo)
+
+      if Dir.exist?(target_dir) && Dir.exist?(File.join(target_dir, ".git"))
+        Rails.logger.info "Pulling latest for #{org}/#{repo}..."
+        system("cd '#{target_dir}' && git pull")
+      else
+        Rails.logger.info "Cloning #{org}/#{repo}..."
+        system("git clone #{url} '#{target_dir}'")
+      end
+    end
+
+    Rails.logger.info "Done cloning and updating all projects!"
+  end
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,9 +1,9 @@
 class Project
   include MarkdownRenderable
-  attr_reader :repo, :project_name, :title, :author, :description, :created_at, :content
+  attr_reader :user, :project_name, :title, :author, :description, :created_at, :content
 
   def initialize(attributes = {})
-    @repo = attributes[:repo]
+    @user = attributes[:user]
     @project_name = attributes[:project_name]
     @title = attributes[:title]
     @author = attributes[:author]
@@ -13,55 +13,112 @@ class Project
   end
 
   def name
-    title
+    title.presence || project_name.titleize
   end
 
   def github_slug
-    "#{repo}/#{project_name}"
+    "#{user}/#{project_name}"
   end
 
   def github_repo
     "https://github.com/#{github_slug}"
   end
 
+  def author_display
+    return "@#{user}" if author.blank?
+    author
+  end
+
+  def user_link
+    "https://github.com/#{user}"
+  end
+
   def created_at_date
+    return nil unless created_at
     Date.parse(created_at)
+  rescue Date::Error
+    nil
   end
 
   def formatted_created_at
+    return nil unless created_at_date
     created_at_date.strftime("%B %d, %Y")
   end
 
-  def self.all
-    Dir.glob(Rails.root.join("content/projects/*/*/journal.md")).map do |file|
-      content = File.read(file)
-      metadata, _ = parse_frontmatter(content)
+  def has_creation_date?
+    created_at_date.present?
+  end
 
-      # Extract repo and project name from path
-      path_parts = file.split("/")
-      repo = path_parts[-3]
-      project_name = path_parts[-2]
+  def has_journal?
+    # Find journal file, case-insensitive
+    dir = Rails.root.join("content/projects", user, project_name)
+    Dir.glob(File.join(dir, "*")).any? { |f| File.basename(f).downcase == "journal.md" }
+  end
+
+  def self.all
+    Dir.glob(Rails.root.join("content/projects/*/*")).map do |dir|
+      next unless File.directory?(dir)
+
+      # Extract user and project name from path
+      path_parts = dir.split("/")
+      user = path_parts[-2]
+      project_name = path_parts[-1]
+
+      # Find journal file, case-insensitive
+      journal_path = Dir.glob(File.join(dir, "*")).find { |f| File.basename(f).downcase == "journal.md" }
+
+      metadata = {}
+      if journal_path && File.exist?(journal_path)
+        content = File.read(journal_path)
+        metadata, _ = parse_frontmatter(content)
+      end
+
+      unless Rails.env.development?
+        next if user == "hackclub" && project_name == "awesome-project"
+      end
 
       new(
-        repo: repo,
+        user: user,
         project_name: project_name,
         title: metadata["title"],
         author: metadata["author"],
         description: metadata["description"],
         created_at: metadata["created_at"]
       )
-    end.sort_by(&:created_at_date).reverse
+    end.compact
   end
 
-  def self.find(repo, project_name)
-    file_path = Rails.root.join("content/projects", repo, project_name, "journal.md")
+  def self.working
+    all.select do |project|
+      journal_path = Rails.root.join("content/projects", project.user, project.project_name, "journal.md")
+      next false unless File.exist?(journal_path)
+
+      content = File.read(journal_path)
+      metadata, _ = parse_frontmatter(content)
+
+      # Check if all required metadata is present
+      required_fields = [ "title", "author", "description", "created_at" ]
+      next false unless required_fields.all? { |field| metadata[field].present? }
+
+      # Update the project with metadata
+      project.instance_variable_set(:@title, metadata["title"])
+      project.instance_variable_set(:@author, metadata["author"])
+      project.instance_variable_set(:@description, metadata["description"])
+      project.instance_variable_set(:@created_at, metadata["created_at"])
+
+      true
+    end
+  end
+
+  def self.find(user, project_name)
+    file_path = Rails.root.join("content/projects", user, project_name, "journal.md")
     return nil unless File.exist?(file_path)
 
     content = File.read(file_path)
     metadata, markdown_content = parse_frontmatter(content)
 
     new(
-      repo: repo,
+      user: user,
       project_name: project_name,
       title: metadata["title"],
       author: metadata["author"],

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -1,19 +1,49 @@
 <div class="mt-16 md:mt-12 p-8 md:p-12">
   
-  <div class = "">
-    <p class="font-bold text-3xl">Check out what others are building!</p>
-    <p class="font-bold opacity-70 mt-8"><i><%= pluralize(@projects.count, "project") %> <%= @projects.count == 1 ? "has" : "have" %> been started:</i></p>
+  <p class="font-bold text-3xl">Check out what others are building!</p>
+  <p class="font-bold opacity-70 mt-8"><i><%= pluralize(@projects.count, "project") %> <%= @projects.count == 1 ? "has" : "have" %> been started:</i></p>
 
-    <div class="grid md:grid-cols-3 gap-4 mt-4 sm:grid-cols-2 grid-cols-1">
-      <% @projects.each do |project| %>
-        <%= link_to project_path(repo: project.repo, project_name: project.project_name), class: "block bg-[#2E2A54] border-2 border-[#544FFF] max-w-4xl py-8 px-8 rounded-lg text-white hover:bg-[#3A3A6D] transition duration-100 transition-transform hover:scale-102" do %>
-          <h1 class="text-2xl"><%= project.name %> <span class="text-base text-[#96ABF9]">(<%= project.github_slug %>)</span></h1>
-          <p class="mb-2">created by <span class="text-[#96ABF9]">[<%= project.author %>]</span></p>
-          <p class="opacity-70"><%= project.description %></p>
-          <p class="opacity-70 mt-2">Started on <%= project.formatted_created_at %></p>
+  <div class="grid md:grid-cols-3 gap-4 mt-4 sm:grid-cols-2 grid-cols-1">
+    <% @projects.each do |project| %>
+      <div class="bg-[#2E2A54] border-2 border-[#544FFF] rounded-lg text-white hover:bg-[#3A3A6D] transition duration-100 transition-transform hover:scale-102 p-8 h-full flex flex-col">
+        <% if project.has_journal? %>
+          <%= link_to project_path(user: project.user, project_name: project.project_name), class: "block mb-2" do %>
+            <h1 class="text-2xl font-bold"><%= project.name.truncate(25) %></h1>
+          <% end %>
+        <% else %>
+          <h1 class="text-2xl font-bold mb-2">
+            <%= project.name.truncate(25) %>
+          </h1>
+          <p class="text-sm font-bold text-yellow-300">⚠️ This project lacks a <code>journal.md</code> file.</p>
         <% end %>
-      <% end %>
-    </div>
+        <%= link_to project.github_repo, target: "_blank", class: "text-base text-[#96ABF9] text-sm rounded px-2 py-1 inline-block" do %>
+          [<%= project.github_slug %>]
+        <% end %>
+        <div class="mb-4 text-[#b3aaff] text-sm opacity-70">
+          Created by
+          <% if project.author.present? %>
+            <%= link_to project.user_link, target: "_blank", class: "text-base text-[#96ABF9] text-sm rounded px-2 py-1 inline-block" do %>
+              [<%= project.author %>]
+            <% end %>
+          <% else %>
+            <%= project.author_display %>
+          <% end %>
+          <% if project.has_creation_date? %>
+            <span class="ml-2">• Started on <%= project.formatted_created_at %></span>
+          <% end %>
+        </div>
+        <% if project.description.present? %>
+          <p class="opacity-80 mt-auto"><%= project.description.truncate(120) %></p>
+        <% end %>
+        <% if Rails.env.development? %>
+          <summary>
+            <details>
+              <%= project.inspect %>
+            </details>
+          </summary>
+        <% end %>
+      </div>
+    <% end %>
   </div>
 
 </div>

--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -6,4 +6,13 @@ Rails.application.configure do
   config.good_job.cleanup_interval_seconds = 3600
 
   config.good_job.execution_mode = :async
+
+  config.good_job.enable_cron = Rails.env.production?
+  config.good_job.cron_graceful_restart_period = 1.minute
+  config.good_job.cron = {
+    clone_projects: {
+      cron: "*/10 * * * *",
+      class: "CloneProjectsJob"
+    }
+  }
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
   root "landing#index"
   resources :users
   get "/projects", to: "projects#index"
-  get "/projects/:repo/:project_name", to: "projects#show", as: :project
+  get "/projects/:user/:project_name", to: "projects#show", as: :project
 
   get "/info", to: "info#show"
 

--- a/lib/tasks/clone_projects.rake
+++ b/lib/tasks/clone_projects.rake
@@ -1,0 +1,6 @@
+namespace :projects do
+  desc "Clone or update all projects from submissions.yml"
+  task clone: :environment do
+    CloneProjectsJob.perform_now
+  end
+end


### PR DESCRIPTION
Now the repos in `submissions.yml` are actually loaded into the site. It should happen automatically (once on startup, once every 5 min, and triggered if someone loads the page when no projects are cloned), but if you need to trigger it manually you can also run `bin/rails projects:clone`.

They get listed on `/projects`:
<img width="1433" alt="Screenshot 2025-05-20 at 13 34 45" src="https://github.com/user-attachments/assets/0d9e0144-464c-4b46-9f7c-943394299106" />

They also get warnings if something is wrong about their submission:
<img width="476" alt="Screenshot 2025-05-20 at 13 35 17" src="https://github.com/user-attachments/assets/a230c001-d6b3-4ca4-8b10-b3a00be4ebb5" />