### PR TITLE
Fix typo in submitting page and make #highway-pitstop a link

### DIFF
--- a/app/views/advanced/submitting.md
+++ b/app/views/advanced/submitting.md
@@ -34,7 +34,7 @@ Before submitting, please *absolutely* make sure of the following:
 
 ## Submitting
 
-Once you are absolutely sure you have met the above requirements, post your project in #highway-pistop! Here's what you should include:
+Once you are absolutely sure you have met the above requirements, post your project in [#highway-pitstop](https://hackclub.slack.com/archives/C08S22XRYMU)! Here's what you should include:
 
 ```
 **Name of project: **


### PR DESCRIPTION
#highway-pitstop is misspelled as #highway-pistop, and I made it a link to the channel for convenience.