### PR TITLE
add pulsar and blade to submissions.yml

### DIFF
--- a/submissions.yml
+++ b/submissions.yml
@@ -926,3 +926,4 @@ projects:
   - "https://github.com/Limit-sest/multi-tool"
   - "https://github.com/code-chandan/MechaGrip"
   - "https://github.com/code-chandan/uchihaboard"
+  - "https://github.com/TheScientist101/pulsar"

--- a/submissions.yml
+++ b/submissions.yml
@@ -927,3 +927,4 @@ projects:
   - "https://github.com/code-chandan/MechaGrip"
   - "https://github.com/code-chandan/uchihaboard"
   - "https://github.com/TheScientist101/pulsar"
+  - "https://github.com/TheScientist101/blade"


### PR DESCRIPTION
I have two projects I wanted to add, so I figured I'd add them in one PR instead of two.

`pulsar` is a meshtastic expansion board to one of my other highway projects [astra](https://github.com/TheScientist101/astra), which is a drone.

`blade` appears to be a USB mass storage device, but is really a rubber ducky USB, useful for pranks and ethical hacking.